### PR TITLE
Reorganiza estrutura do projeto e imprime depósitos na página principal.

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -29,7 +29,7 @@ DJANGO_APPS = (
     'django.contrib.staticfiles',
 
     # Useful template tags:
-    # 'django.contrib.humanize',
+    'django.contrib.humanize',
 
     # Admin
     'django.contrib.admin',

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     url(r'^accounts/', include('allauth.urls')),
 
     # Your stuff: custom urls includes go here
-    url(r'frontdesk/', include('frontdesk.urls')),
+    url(r'frontdesk/', include('frontdesk.urls', namespace='frontdesk')),
 
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,12 +5,13 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.views.generic import TemplateView
 from django.views import defaults as default_views
 
+from penne_core import views as pc_views  # views em nível de projeto
+
+
 urlpatterns = [
-    url(r'^$', TemplateView.as_view(template_name='pages/home.html'), name='home'),
-    url(r'^about/$', TemplateView.as_view(template_name='pages/about.html'), name='about'),
+    url(r'^$', pc_views.index, name='index'),
 
     # Django Admin, use {% url 'admin:index' %}
     url(settings.ADMIN_URL, include(admin.site.urls)),

--- a/frontdesk/models.py
+++ b/frontdesk/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.urls import reverse
 
 from model_utils.models import TimeStampedModel
 from model_utils.fields import StatusField, MonitorField
@@ -23,6 +24,9 @@ class Deposit(TimeStampedModel):
 
     status = StatusField()
     status_changed = MonitorField(monitor='status')
+
+    def get_absolute_url(self):
+        return reverse('frontdesk:deposit', args=[self.pk])
 
 
 class Package(TimeStampedModel):

--- a/frontdesk/models.py
+++ b/frontdesk/models.py
@@ -25,9 +25,6 @@ class Deposit(TimeStampedModel):
     status = StatusField()
     status_changed = MonitorField(monitor='status')
 
-    def get_absolute_url(self):
-        return reverse('frontdesk:deposit', args=[self.pk])
-
 
 class Package(TimeStampedModel):
     """Pacote depositado para inclusão na coleção.

--- a/frontdesk/urls.py
+++ b/frontdesk/urls.py
@@ -4,6 +4,5 @@ from . import views
 
 
 urlpatterns = [
-        url(r'^$', views.main, name='main'),
         url(r'^deposits/$', views.deposit_package, name='deposits'),
 ]

--- a/frontdesk/urls.py
+++ b/frontdesk/urls.py
@@ -4,6 +4,6 @@ from . import views
 
 
 urlpatterns = [
-        url(r'^deposit/$', views.deposit_package),
-        url(r'^dashboard/$', views.deposit_dashboard),
+        url(r'^$', views.main, name='main'),
+        url(r'^deposits/$', views.deposit_package, name='deposits'),
 ]

--- a/frontdesk/utils.py
+++ b/frontdesk/utils.py
@@ -1,8 +1,4 @@
 import hashlib
-import threading
-
-
-_CHECKSUM_FILE_LOCK = threading.Lock()
 
 
 def checksum_file(file, algorithm=hashlib.md5):
@@ -39,11 +35,10 @@ def safe_checksum_file(file, algorithm=hashlib.md5):
     if not file.seekable():
         raise TypeError('Object "file" does not support random access.')
 
-    with _CHECKSUM_FILE_LOCK:
-        former_offset = file.tell()
-        try:
-            return checksum_file(file, algorithm=algorithm)
+    former_offset = file.tell()
+    try:
+        return checksum_file(file, algorithm=algorithm)
 
-        finally:
-            file.seek(former_offset)
+    finally:
+        file.seek(former_offset)
 

--- a/frontdesk/views.py
+++ b/frontdesk/views.py
@@ -1,12 +1,19 @@
 from django.views.decorators.csrf import csrf_exempt
-from django.shortcuts import render
+from django.shortcuts import (
+        render,
+        get_object_or_404,
+)
 from django.http import (
         JsonResponse,
         HttpResponseBadRequest,
         HttpResponseNotAllowed,
 )
 
-from . import transactions, forms
+from . import (
+        transactions,
+        forms,
+        models,
+)
 
 
 @csrf_exempt
@@ -28,7 +35,14 @@ def deposit_package(request):
 
 
 def deposit_dashboard(request):
+    show_deposit = request.GET.get('show', None)
 
-    context = {}
+    deposits = models.Deposit.objects.order_by('-created')[:10]
+    if show_deposit:
+        detailed_deposit = get_object_or_404(models.Deposit, pk=show_deposit)
+    else:
+        detailed_deposit = models.Deposit.objects.order_by('-created').first()
 
+    context = {'deposits': deposits, 'detailed_deposit': detailed_deposit}
     return render(request, 'frontdesk/dashboard.html', context)
+

--- a/frontdesk/views.py
+++ b/frontdesk/views.py
@@ -1,8 +1,4 @@
 from django.views.decorators.csrf import csrf_exempt
-from django.shortcuts import (
-        render,
-        get_object_or_404,
-)
 from django.http import (
         JsonResponse,
         HttpResponseBadRequest,
@@ -23,26 +19,17 @@ def deposit_package(request):
 
     form = forms.DepositForm(request.POST, request.FILES)
     if form.is_valid():
-        deposit_id = transactions.deposit_package(
-            request.FILES['package'],
-            request.POST['md5_sum']
-        )
+        try:
+            deposit_id = transactions.deposit_package(
+                request.FILES['package'],
+                request.POST['md5_sum'])
+
+        except transactions.ChecksumError as exc:
+            LOGGER.exception(exc)
+            return HttpResponseBadRequest()
 
         return JsonResponse({'deposit_id': deposit_id})
 
     else:
         return HttpResponseBadRequest()
-
-
-def deposit_dashboard(request):
-    show_deposit = request.GET.get('show', None)
-
-    deposits = models.Deposit.objects.order_by('-created')[:10]
-    if show_deposit:
-        detailed_deposit = get_object_or_404(models.Deposit, pk=show_deposit)
-    else:
-        detailed_deposit = models.Deposit.objects.order_by('-created').first()
-
-    context = {'deposits': deposits, 'detailed_deposit': detailed_deposit}
-    return render(request, 'frontdesk/dashboard.html', context)
 

--- a/penne_core/templates/frontdesk/dashboard.html
+++ b/penne_core/templates/frontdesk/dashboard.html
@@ -1,3 +1,4 @@
+{% load humanize %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -113,7 +114,14 @@
       <!-- sidebar menu: : style can be found in sidebar.less -->
       <ul class="sidebar-menu">
         <li class="header">DEPOSITS</li>
-        <li><a href="index.html"><i class="fa fa-circle-o text-aqua"></i>#230 - 22, janeiro 2016</a></li>
+        {% for deposit in deposits %}
+        <li>
+        <a href="{{ deposit.get_absolute_url }}"><i class="fa fa-circle-o text-aqua"></i>#{{deposit.pk}} - {{deposit.created|naturaltime}}</a>
+        </li>
+        {% endfor %}
+        <li>
+          <a href="index.html"><i class="fa fa-circle-o text-aqua"></i>#230 - 22, janeiro 2016</a>
+        </li>
         <li class="active"><a href="index.html"><i class="fa fa-circle-o text-green"></i>#229 - 21, janeiro 2016</a></li>
         <li><a href="index.html"><i class="fa fa-circle-o text-red"></i>#228 - 20, janeiro 2016</a></li>
       </ul>
@@ -126,18 +134,28 @@
     <!-- Content Header (Page header) -->
     <section class="content-header">
       <h1>
-        Deposit (#299)
+        Deposit (#{{ detailed_deposit.pk }})
       </h1>
     </section>
 
     <!-- Main content -->
     <section class="content">
         <div class="info-box">
+        {% if detailed_deposit.status == 'deposited' %}
+          <span class="info-box-icon bg-blue"><i class="fa fa-inbox"></i></span>
+        {% elif detailed_deposit.status == 'rejected' %} 
+          <span class="info-box-icon bg-red"><i class="fa fa-thumbs-o-down"></i></span>
+        {% else %}
           <span class="info-box-icon bg-green"><i class="fa fa-thumbs-o-up"></i></span>
+        {% endif %}
+
           <div class="info-box-content">
-            <span class="info-box-number">(#299) 1807-8672_asas_38_2_40.zip</span>
-            <div><b>MD5 Sum:</b> 8913jhdiuh37y489fc3h02j92r3u3089fu380fu38yfw9ywe7io7w</div>
-            <div><b>depositado em:</b> 22 de janeiro de 2016 por <b>Cabo Verde</b></div>            
+              <span class="info-box-number">
+                {{ detailed_deposit.package.file.name }}
+                <a href="{{ detailed_deposit.package.file.url }}"><i class="fa fa-cloud-download"></i>Download</a>
+              </span>
+              <div><b>MD5 Sum:</b> {{ detailed_deposit.package.md5_sum }}</div>
+              <div><b>Depositado em:</b> {{ detailed_deposit.created }}</div>            
           </div>
           <!-- /.info-box-content -->
         </div>

--- a/penne_core/templates/penne_core/index.html
+++ b/penne_core/templates/penne_core/index.html
@@ -116,7 +116,7 @@
         <li class="header">DEPOSITS</li>
         {% for deposit in deposits %}
         <li>
-        <a href="{{ deposit.get_absolute_url }}"><i class="fa fa-circle-o text-aqua"></i>#{{deposit.pk}} - {{deposit.created|naturaltime}}</a>
+        <a href="/?show={{ deposit.pk }}"><i class="fa fa-circle-o text-aqua"></i>#{{ deposit.pk }} - {{ deposit.created|naturaltime }}</a>
         </li>
         {% endfor %}
         <li>

--- a/penne_core/views.py
+++ b/penne_core/views.py
@@ -1,0 +1,23 @@
+from django.shortcuts import (
+        render,
+        get_object_or_404,
+)
+
+import frontdesk
+
+
+def index(request):
+    show_deposit = request.GET.get('show', None)
+
+    deposits = frontdesk.models.Deposit.objects.order_by('-created')[:10]
+    if show_deposit:
+        detailed_deposit = get_object_or_404(frontdesk.models.Deposit,
+                pk=show_deposit)
+    else:
+        detailed_deposit = frontdesk.models.Deposit.objects.order_by(
+                '-created').first()
+
+    context = {'deposits': deposits, 'detailed_deposit': detailed_deposit}
+    return render(request, 'penne_core/index.html', context)
+
+


### PR DESCRIPTION
View-functions que dizem respeito ao projeto, ao invés de apps específicas, foram movidas para ``penne_core.views``. O mesmo ocorreu com os templates.

Houve também uma correção na função ``frontdesk.utils.safe_checksum_file``, que delimitava, de maneira errada, uma região crítica para execução concorrente.