### PR TITLE
Adiciona capacidade de inferir tipo de frontdesk.models.PackageMember.

### DIFF
--- a/frontdesk/models.py
+++ b/frontdesk/models.py
@@ -1,3 +1,5 @@
+import mimetypes
+
 import celery
 from django.db import models
 from django.db.models.signals import post_save
@@ -149,6 +151,21 @@ class PackageMember(models.Model):
                 is_valid = False
 
             return (is_valid, xmlattrs.sps_check_details)
+
+    def guess_type(self):
+        """Infere o mimetype do membro.
+
+        Retorna uma string de texto no formato ``'tipo/subtipo'`` ou ``None``.
+
+        A inferência é realizada por meio da função ``mimetypes.guess_type``,
+        da biblioteca padrão da linguagem. Tipos adicionais -- fora do padrão
+        IANA mas comumente utilizados -- são suportados.
+
+        Mais informação em:
+        https://docs.python.org/3/library/mimetypes.html#mimetypes.guess_type
+        """
+        type, _ = mimetypes.guess_type(self.name, strict=False)
+        return type
 
 
 class XMLMemberControlAttrs(models.Model):

--- a/frontdesk/tests/test_models.py
+++ b/frontdesk/tests/test_models.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+
+from . import modelfactories
+
+
+class PackageMemberTests(TestCase):
+
+    def test_type_guessing_for_xml_members(self):
+        member = modelfactories.PackageMemberFactory(
+                name='0004-2730-aem-60-4/0004-2730-aem-60-4-0407.xml')
+        self.assertEqual('application/xml', member.guess_type())
+
+    def test_type_guessing_for_pdf_members(self):
+        member = modelfactories.PackageMemberFactory(
+                name='0004-2730-aem-60-4/0004-2730-aem-60-4-0299.pdf')
+        self.assertEqual('application/pdf', member.guess_type())
+
+    def test_type_guessing_for_jpg_members(self):
+        member = modelfactories.PackageMemberFactory(
+                name='0004-2730-aem-60-4/0004-2730-aem-60-4-0367-gf01.jpg')
+        self.assertEqual('image/jpeg', member.guess_type())
+
+    def test_type_guessing_for_jpeg_members(self):
+        member = modelfactories.PackageMemberFactory(
+                name='0004-2730-aem-60-4/0004-2730-aem-60-4-0367-gf01.jpeg')
+        self.assertEqual('image/jpeg', member.guess_type())
+
+    def test_type_guessing_for_tif_members(self):
+        member = modelfactories.PackageMemberFactory(
+                name='0004-2730-aem-60-4/0004-2730-aem-60-4-0367-gf01.tif')
+        self.assertEqual('image/tiff', member.guess_type())
+
+    def test_type_guessing_for_tiff_members(self):
+        member = modelfactories.PackageMemberFactory(
+                name='0004-2730-aem-60-4/0004-2730-aem-60-4-0367-gf01.tiff')
+        self.assertEqual('image/tiff', member.guess_type())
+
+    def test_type_guessing_for_members_without_file_extension(self):
+        member = modelfactories.PackageMemberFactory(
+                name='0004-2730-aem-60-4/0004-2730-aem-60-4-0367-gf01')
+        self.assertEqual(None, member.guess_type())
+


### PR DESCRIPTION
Retorna uma string de texto no formato ``'tipo/subtipo'`` ou ``None``.

A inferência é realizada por meio da função ``mimetypes.guess_type``,
da biblioteca padrão da linguagem. Tipos adicionais -- fora do padrão
IANA mas comumente utilizados -- são suportados.

Mais informação em:
https://docs.python.org/3/library/mimetypes.html#mimetypes.guess_type