### PR TITLE
Trata a execução de tarefas assíncronas à partir de eventos do sistema.

### DIFF
--- a/frontdesk/signals.py
+++ b/frontdesk/signals.py
@@ -1,0 +1,16 @@
+import django.dispatch
+
+
+# Evento disparado após a transação ``transactions.deposit_package`` ter
+# sido efetivada com sucesso.
+# O argumento ``instance`` deve ser a instância de ``models.Deposit``
+# recém criada.
+package_deposited = django.dispatch.Signal(providing_args=["instance"])
+
+
+# Evento disparado após a criação de todas as instâncias de
+# ``models.PackageMember`` pela task ``tasks.create_package_members``.
+# O argumento ``instance`` deve ser a instância de ``models.Package`` que
+# contém os membros.
+package_members_created = django.dispatch.Signal(providing_args=["instance"])
+


### PR DESCRIPTION
Os eventos tipo ``post_save`` são emitidos imediatamente após o retorno
do método ``save()`` das instâncias de ``models.Model``. Essa
característica pode levar a erros quando o contexto transacional é
gerido manualmente via gerenciadores de contexto ou decoradores,
pois o evento é emitido antes de a transação ter de fato sido
finalizada (_commit_ ou _rollback_).

A solução proposta aqui utiliza a funcionalidade de *transactional hook* para
registrar *callbacks* à serem executados após a efetivação da transação, que
disparam eventos relacionados ao domínio de negócio da aplicação.

Fixes #31